### PR TITLE
Fix ensure SHELL exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ function isValidEnvironment() {
           process.platform &&
           process.platform.toLowerCase() === 'linux' &&
           process.env &&
+          process.env.SHELL &&
           process.env.SHELL.toLowerCase() === '/bin/bash');
 }
 


### PR DESCRIPTION
Using docker in next.js I have found this error, so it just ensure that SHELL exists:

```
TypeError: Cannot read property 'toLowerCase' of undefined
    at isValidEnvironment (/app/node_modules/is-windows-bash/index.js:8:28)
    at isWindowsBash (/app/node_modules/is-windows-bash/index.js:12:7)
    at HotReloader._callee3$ (/app/node_modules/next/dist/server/hot-reloader.js:4357:87)
    at tryCatch (/app/node_modules/regenerator-runtime/runtime.js:63:40)
    at GeneratorFunctionPrototype.invoke [as _invoke] (/app/node_modules/regenerator-runtime/runtime.js:337:22)
    at GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (/app/node_modules/regenerator-runtime/runtime.js:96:21)
    at step (/app/node_modules/babel-runtime/helpers/asyncToGenerator.js:17:30)
    at /app/node_modules/babel-runtime/helpers/asyncToGenerator.js:28:13
```